### PR TITLE
Bump Rubocop from 0.88 to 0.89

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -222,6 +222,21 @@ Style/AccessorGrouping:
 Style/StringLiteralsInInterpolation:
   Enabled: false
 
+Style/ExplicitBlockArgument:
+  Enabled: false
+
+Style/GlobalStdStream:
+  Enabled: false
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/SingleArgumentDig:
+  Enabled: false
+
+Style/StringConcatenation:
+  Enabled: false
+
 Lint/DisjunctiveAssignmentInConstructor:
   Enabled: true
 
@@ -240,6 +255,9 @@ Lint/ToJSON:
 Gemspec/RubyVersionGlobalsUsage:
   Enabled: true
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Lint/NonDeterministicRequireOrder:
   Enabled: false
 
@@ -257,3 +275,30 @@ Lint/StructNewOverride:
 
 Lint/DuplicateElsifCondition:
   Enabled: true
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: false
+
+Lint/DuplicateRescueException:
+  Enabled: false
+
+Lint/EmptyConditionalBody:
+  Enabled: false
+
+Lint/FloatComparison:
+  Enabled: false
+
+Lint/MissingSuper:
+  Enabled: false
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: false
+
+Lint/SelfAssignment:
+  Enabled: false
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: false
+
+Lint/UnreachableLoop:
+  Enabled: false

--- a/lib/rubocopital/version.rb
+++ b/lib/rubocopital/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rubocopital
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/rubocopital.gemspec
+++ b/rubocopital.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", "~> 0.88.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.89.0"
   spec.add_runtime_dependency "rubocop-performance", "~> 1.7.1"
   spec.add_runtime_dependency "rubocop-rails", "2.7.0"
   spec.add_runtime_dependency "rubocop-rspec", "1.42.0"


### PR DESCRIPTION
Added some configurations:

- Style/ExplicitBlockArgument
- Style/GlobalStdStream
- Style/OptionalBooleanParameter
- Style/SingleArgumentDig
- Style/StringConcatenation

- Lint/BinaryOperatorWithIdenticalOperands
- Lint/DuplicateRescueException
- Lint/EmptyConditionalBody
- Lint/FloatComparison
- Lint/MissingSuper
- Lint/OutOfRangeRegexpRef
- Lint/SelfAssignment
- Lint/TopLevelReturnWithArgument
- Lint/UnreachableLoop